### PR TITLE
Add link to Claude Agent SDK multi-agent template

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repo includes the binbash GenAI - ML projects
 ## Agent | AWS Bedrock AgentCore
 - 🚧 https://github.com/awslabs/amazon-bedrock-agentcore-samples/tree/main
 - 🚧 https://github.com/awslabs/fullstack-solution-template-for-agentcore
+- 🚧 https://github.com/awslabs/fullstack-solution-template-for-agentcore/tree/main/patterns/claude-agent-sdk-multi-agent
 
 ## Agent | Speech2Text & Text2Speech
 - 🚧 https://github.com/binbashar/amazon-bedrock-voice-conversation


### PR DESCRIPTION
## What?
* Adding Claude Agent SDK Multi-Agent Pattern

## Why?
* This pattern integrates Anthropic's Claude Agent SDK with Amazon Bedrock AgentCore, providing Code Interpreter access via an in-process MCP server, subagent delegation via the Task tool, and Gateway tool integration. For a simpler single-agent version without subagents, see the claude-agent-sdk-single-agent pattern.


## References
* https://github.com/awslabs/fullstack-solution-template-for-agentcore/tree/main/patterns/claude-agent-sdk-multi-agent