### PR TITLE
Add Amazon Bedrock agents link for HCLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This repo includes the binbash GenAI - ML projects
 - 🚧 https://github.com/aws-samples/awesome-ai-agents-hcls
 - 📙 https://github.com/aws-samples/aws-healthcare-lifescience-ai-ml-sample-notebooks
 - 📙 https://catalog.workshops.aws/hcls-aiml/en-US/breast-cancer-classification
+- 📙 https://github.com/aws-samples/amazon-bedrock-agents-healthcare-lifesciences
 
 
 # CONSIDERATIONS


### PR DESCRIPTION
## What?
* Adding aws-samples link: amazon-bedrock-agents-healthcare-lifesciences in the README.md related section.

## Why?
* Relevant for HCLS AI projects.

## References
* https://github.com/aws-samples/amazon-bedrock-agents-healthcare-lifesciences

## Before release
Review the checklist [here](https://binbash.atlassian.net/l/cp/BthxSQ0j)
